### PR TITLE
Add window.location.hash to the redirect URL

### DIFF
--- a/ui/src/pages/login-page/components/plex-login/PlexLogin.jsx
+++ b/ui/src/pages/login-page/components/plex-login/PlexLogin.jsx
@@ -62,7 +62,7 @@ class PlexLogin extends Component {
             const location = window.location.pathname;
             const pathSplit = location.split('/');
             const service = pathSplit[1];
-            const path = pathSplit.length < 2 ? '/' : location.substr(service.length + 1) + window.location.search;
+            const path = pathSplit.length < 2 ? '/' : location.substring(service.length + 1) + window.location.search + window.location.hash;
 
             return {
                 service,


### PR DESCRIPTION
Useful for sites using hash routing.