### PR TITLE
Fix null dereference in ValidateAuthenticationStatus

### DIFF
--- a/backend/PlexSSO/Service/Auth/AuthenticationValidator.cs
+++ b/backend/PlexSSO/Service/Auth/AuthenticationValidator.cs
@@ -32,7 +32,7 @@ namespace PlexSSO.Service.Auth
                 );
             }
 
-            if (!string.IsNullOrWhiteSpace(serviceUri.Value)
+            if (!string.IsNullOrWhiteSpace(serviceUri?.Value)
                 && TryGetFirstMatchingAccessControl(serviceName, serviceUri, identity,
                     out var matchingAccessControl))
             {


### PR DESCRIPTION
The [example config](https://github.com/drkno/PlexSSO/blob/main/examples/nginx/sso_common.conf#L9) doesn't pass `X-PlexSSO-Original-URI` for the auth request, so `serviceUri` will be null. With the applied fix, it works for me.

```plexsso  | fail: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware[1]
plexsso  |       An unhandled exception has occurred while executing the request.
plexsso  |       System.NullReferenceException: Object reference not set to an instance of an object.
plexsso  |          at PlexSSO.Service.Auth.AuthenticationValidator.ValidateAuthenticationStatus(Identity identity, ServiceName serviceName, ServiceUri serviceUri)
plexsso  |          at PlexSSO.Controllers.SsoController.Get()
plexsso  |          at lambda_method1(Closure, Object, Object[])
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncObjectResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeActionMethodAsync()
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeNextActionFilterAsync()
plexsso  |       --- End of stack trace from previous location ---
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
plexsso  |       --- End of stack trace from previous location ---
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
plexsso  |       --- End of stack trace from previous location ---
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
plexsso  |          at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
plexsso  |          at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
plexsso  |          at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
plexsso  |          at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddlewareImpl.<Invoke>g__Awaited|10_0(ExceptionHandlerMiddlewareImpl middleware, HttpContext context, Task task)```